### PR TITLE
Update index.html

### DIFF
--- a/pi/index.html
+++ b/pi/index.html
@@ -88,6 +88,7 @@ Echo "# Create ssh key if it does not exist"
 Echo "# -----------------------------------------------"
 FILE=$HOME/.ssh/id_rsa.pub
 if [ ! -e "$FILE" ]; then
+     mkdir -p -m700 $HOME/.ssh
      yes y | ssh-keygen -q -N "" -f .ssh/id_rsa
 fi
 echo

--- a/pi/index.html
+++ b/pi/index.html
@@ -88,7 +88,7 @@ Echo "# Create ssh key if it does not exist"
 Echo "# -----------------------------------------------"
 FILE=$HOME/.ssh/id_rsa.pub
 if [ ! -e "$FILE" ]; then
-     mkdir -p -m700 $HOME/.ssh
+     mkdir -p -m 700 $HOME/.ssh
      yes y | ssh-keygen -q -N "" -f .ssh/id_rsa
 fi
 echo


### PR DESCRIPTION
.ssh dir does not exist on the raspberrypi when the sshkey is generated causing a failure.
This will add the dir or silently ignore the command if it already exists.